### PR TITLE
Implement 'Add Course' functionality

### DIFF
--- a/as-developers/frontend/dimspace-main/dimapp/templates/addcourse.html
+++ b/as-developers/frontend/dimspace-main/dimapp/templates/addcourse.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block content %}
+{% load dimspace_extras %}
+<div class="container">
+    <div class="text mt-5" style="margin-bottom: 2em;">
+        <h1>Add New Course</h1>
+    </div>
+
+    <div class="col courses border border-secondary rounded" style="display: flex; flex-direction: column; padding-bottom: 25px; float: none; overflow: hidden">
+        <h4 style="margin: 15px;">New Course Form</h4>
+
+        <form style="margin: 15px; margin-right: 25%" name="newcourseform" method="post">
+            <div class="form-group">
+              <label for="inputcode">Course Code</label>
+              <input type="code" name="code" class="form-control" id="inputcode" aria-describedby="codeHelp" placeholder="Enter course code">
+              <small id="codeHelp" class="form-text text-muted">Example: SENG 321</small>
+            </div>
+            <div class="form-group">
+              <label for="inputInstructor">Instructor Name</label>
+              <input type="instructor" name="instructor" class="form-control" id="inputInstructor" placeholder="Instructor">
+            </div>
+            <div class="form-group mb-3">
+                <label for="inputName">Course Name</label>
+                <input type="name" name="name" class="form-control" id="inputName" placeholder="Enter the name of the course">
+            </div>
+            <button type="submit" class="btn btn-primary">Submit</button>
+          </form>
+    </div>
+</div>
+{% endblock %}

--- a/as-developers/frontend/dimspace-main/dimapp/templates/addcourse_success.html
+++ b/as-developers/frontend/dimspace-main/dimapp/templates/addcourse_success.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+{% load dimspace_extras %}
+<div class="container">
+    <div class="text mt-5" style="margin-bottom: 2em;">
+        <h1>Add New Course</h1>
+    </div>
+
+    <div class="text mt-5 mb-5" style="margin-bottom: 2em;">
+        <h5>Course added successfully! You may now exit this page.</h5>
+    </div>
+
+    <a class="btn btn-primary" href="/dimspace/">Return to Home</a>
+</div>
+{% endblock %}

--- a/as-developers/frontend/dimspace-main/dimapp/templates/home.html
+++ b/as-developers/frontend/dimspace-main/dimapp/templates/home.html
@@ -43,9 +43,9 @@ active
 
     <div class="col courses border border-secondary rounded" style="display: flex; flex-direction: column; padding-bottom: 25px; float: none; overflow: hidden">
         <h4 style="margin: 15px;">Courses</h1>
-        <div class="d-flex flex-row justify-content-around">
+        <div class="d-flex flex-row flex-wrap justify-content-around">
             {% for course in courses %}
-                <div class="card" style="width: 18rem;">
+                <div class="card mb-3" style="width: 18rem;">
                     <div class="card-body">
                         <h5 class="card-title" style="margin-bottom: 1em;">{{ course.code }}</h5>
                         {% with course_info|index:forloop.counter0 as info %}
@@ -57,5 +57,6 @@ active
             {% endfor %}
         </div>
     </div>
+    <a class="btn btn-primary mt-3" href="./addcourse/" style="float: right">Add Course</a>
 </div>
 {% endblock %}

--- a/as-developers/frontend/dimspace-main/dimspace/urls.py
+++ b/as-developers/frontend/dimspace-main/dimspace/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from dimapp.views import Home, CourseHome, CourseLectures, CourseAssignments, CourseLabs, Grades, ViewAnnouncement
+from dimapp.views import Home, CourseHome, CourseLectures, CourseAssignments, CourseLabs, Grades, ViewAnnouncement, AddCourse, AddCourseSuccess
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -26,4 +26,6 @@ urlpatterns = [
     path('dimspace/course/<int:course_id>/labs/', CourseLabs.as_view()),
     path('dimspace/course/<int:course_id>/announcements/<int:content_id>', ViewAnnouncement.as_view()),
     path('dimspace/grades/', Grades.as_view()),
+    path('dimspace/addcourse/', AddCourse.as_view()),
+    path('dimspace/addcourse/success', AddCourseSuccess.as_view())
 ]


### PR DESCRIPTION
Includes a button on the Home page that leads to a new "Add Course" page. This form collects the course code, instructor, and name provided and turns it into JSON data. This is then sent via POST to the `/course` spring API endpoint.