### PR TITLE
Merge grade weights into main

### DIFF
--- a/as-developers/frontend/dimspace-main/dimapp/templates/grades.html
+++ b/as-developers/frontend/dimspace-main/dimapp/templates/grades.html
@@ -4,6 +4,7 @@
 active
 {% endblock %}
 
+{% load dimspace_extras %}
 {% block content %}
 <div class="container">
     <nav aria-label="breadcrumb" style="margin-top: 15px;">
@@ -32,22 +33,25 @@ active
                                     <th scope="col">Grade Item</th>
                                     <th scope="col">Points</th>
                                     <th scope="col">Grade</th>
+                                    <th scope="col">Weight</th>
                                     <th scope="col">Comments & Assessments</th>
                                 </tr>
                                 </thead>
                                 <tbody>
                                 {% for grade in grades %}
                                     <tr>
-                                        <td>{{grade.itemName}}</td>
-                                        <td>{{grade.markNumerator|default_if_none:"-"}} / {{grade.markDenominator|default_if_none:""}}</td>
-                                        <td>{{grade.percentage|default_if_none:"-"}}</td>
-                                        <td>{{grade.comment|default_if_none:""}}</td>
+                                        <td>{{ grade.itemName }}</td>
+                                        <td>{{ grade.markNumerator|default_if_none:"-" }} / {{ grade.markDenominator|default_if_none:"" }}</td>
+                                        <td>{{ grade.percentage|default_if_none:"-" }}</td>
+                                        <td>{{ grade.weight }}</td>
+                                        <td>{{ grade.comment|default_if_none:"" }}</td>
                                     </tr>
                                 {% endfor %}
                                 </tbody>
                             </table>
                             {% endwith %}
                             <p class="card-text"><small class="text-muted">Updated X days ago</small></p>
+                            <h5 class="text" style="float: right">Total achieved grade: <b>{{ all_cumulative_grades|index:forloop.counter0 }}</b></h5>
                         </div>
                     </div>
                 </div>

--- a/as-developers/frontend/dimspace-main/dimapp/views.py
+++ b/as-developers/frontend/dimspace-main/dimapp/views.py
@@ -54,14 +54,23 @@ class Grades(TemplateView):
         courses = []
         courses.append(get_from_api("grades"))
 
+        all_cumulative_grades = []
         for course in courses:
+            cumulative_grade = 0
             for grade in course['grades']:
                 if grade['percentage']:
+                    # Add weighted grade to cumulative_grade
+                    cumulative_grade += (grade['percentage'] * grade['weight'])
+                    # Convert decimal grade to percentage string for displaying
                     grade['percentage'] = str(f"%{grade['percentage']*100}")
+            # Convert decimal cumulative grade to percentage string
+            cumulative_grade = str(f"%{cumulative_grade*100}")
+            all_cumulative_grades.append(cumulative_grade)
 
         # Set context
         context = super().get_context_data(**kwargs)
         context['courses'] = courses
+        context['all_cumulative_grades'] = all_cumulative_grades
         return context
 
 


### PR DESCRIPTION
Adds grade weights functionality to the Dimspace frontend. Grades page will now have a 'weight' column, and a cumulative achieved grade at the bottom of each course grade table. 